### PR TITLE
Fix Search For Icinga Web 2.12.5

### DIFF
--- a/dark-theme.less
+++ b/dark-theme.less
@@ -169,11 +169,6 @@ input[type="submit"] {
 #menu {
     input.search {
         color: @text-color;
-        background-image: url(../img/icons/search_white.png);
-
-        &:focus {
-            background-image: url(../img/icons/search_white.png) !important;
-        }
     }
 
     .nav-level-1>.nav-item {


### PR DESCRIPTION
In Icinga Web 2 version 2.12.5, the search icon was replaced by a Font Awesome icon[^0]. To match the other upstream changes, a part of this change is required for this theme as well.

Fixes #2.

[^0]: https://github.com/Icinga/icingaweb2/commit/ad5625ff9548e31f27516af15592c44eccf41a87